### PR TITLE
fix(PLATFORM-10764): fix php warning when accessing variable that is not set

### DIFF
--- a/includes/LST.php
+++ b/includes/LST.php
@@ -594,7 +594,7 @@ class LST {
 				}
 			}
 
-			if ( !$end_off ) {
+			if ( !isset( $end_off ) ) {
 				if ( $nr != 0 ) {
 					$pat = '^(={1,6})\s*[^\s\n=][^\n=]*\s*\1\s*$';
 				} else {
@@ -613,7 +613,7 @@ class LST {
 
 			wfDebug( "LSTH: head offset = $nhead" );
 
-			if ( $end_off ) {
+			if ( !empty( $end_off ) ) {
 				if ( $end_off == -1 ) {
 					return $output;
 				}


### PR DESCRIPTION
https://fandom.atlassian.net/browse/PLATFORM-10764

In PHP 8.0 there is a warning enabled when accessing a varaible that is not set, for example
```
if (  !$end_off  )
```
should be now called as follows to remove warning:
```
if ( !isset( $end_off ) )
```