### PR TITLE
fix(PLATFORM-10784): fix PHP notice

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -226,8 +226,7 @@ class Hooks {
 		if ( $reset['categories'] ?? false ) {
 			$saveCategories = array_combine(
 				$parserOutput->getCategoryNames(),
-				array_map( static fn ( $value ) =>
-					$parserOutput->getCategorySortKey( $value ),
+				array_map( static fn ( $value ) => $parserOutput->getCategorySortKey( $value ),
 					$parserOutput->getCategoryNames()
 				)
 			);
@@ -628,13 +627,15 @@ class Hooks {
 						continue;
 					}
 
-					$parser->getOutput()->mLinks[$nsp] = array_diff_assoc(
-						$parserLinks[$nsp],
+					// @phan-suppress-next-line PhanDeprecatedFunction
+					$mLinks = $parser->getOutput()->getLinks();
+					$mLinks[$nsp] = array_diff_assoc(
+						$link,
 						self::$createdLinks[0][$nsp]
 					);
 
-					if ( count( $parserLinks[$nsp] ) == 0 ) {
-						unset( $parser->getOutput()->mLinks[$nsp] );
+					if ( count( $link ) == 0 ) {
+						unset( $mLinks[$nsp] );
 					}
 				}
 			}
@@ -646,13 +647,15 @@ class Hooks {
 						continue;
 					}
 
-					$parser->getOutput()->mTemplates[$nsp] = array_diff_assoc(
-						$parserTemplates[$nsp],
+					// @phan-suppress-next-line PhanDeprecatedFunction
+					$mTemplates = $parser->getOutput()->getTemplates();
+					$mTemplates[$nsp] = array_diff_assoc(
+						$tpl,
 						self::$createdLinks[1][$nsp]
 					);
 
-					if ( count( $parserTemplates[$nsp] ) == 0 ) {
-						unset( $parser->getOutput()->mTemplates[$nsp] );
+					if ( count( $tpl ) == 0 ) {
+						unset( $mTemplates[$nsp] );
 					}
 				}
 			}


### PR DESCRIPTION
https://fandom.atlassian.net/browse/PLATFORM-10784

This PR introduces a temporary fix for `PHP Notice: Indirect modification of overloaded property` message flood in logs.

**Dev notes**

As it turned out, there is no API in `includes/parser/ParserOutput.php class` that is equivalent to what `extensions/DynamicPageList/includes/Hooks.php` does. Temporary solution is to use the deprecated methods `ParserOutput::&getLinks()` and `ParserOutput::&getTemplates()` as they give direct access to now private arrays `ParserOutput::mLinks` and `ParserOutput::mTemplates`. These methods are marked deprecated from version 1.43 so until DynamicPageList maintainers introduce the solution the implemented approach is good enough.